### PR TITLE
Corrected 'configrue' typo

### DIFF
--- a/LCD101-1024x600-show
+++ b/LCD101-1024x600-show
@@ -49,23 +49,23 @@ fi
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-101-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-101-1024x600.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-101-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-101-1024x600.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-101-1024x600-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-101-1024x600.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-101-1024x600-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-101-1024x600.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-101-1024x600-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-101-1024x600.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 #sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 

--- a/LCD154-show
+++ b/LCD154-show
@@ -67,11 +67,11 @@ sudo cp -rf ./etc/rc.local-154 /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-154  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	sudo cp ./boot/config-154.txt /boot/config.txt
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-154  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-154.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90";then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-154.txt /boot/config.txt
@@ -80,7 +80,7 @@ elif test "$1" = "90" -o "$2" = "90";then
 	sudo cp ./boot/config-154.txt-90 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-154-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 fi
 
 if [ -b /dev/mmcblk0p7 ]; then

--- a/LCD28-show
+++ b/LCD28-show
@@ -56,11 +56,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
         if test "$j" = "retropie"; then
         sudo cp ./boot/config-32.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-32.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90";then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-90-lite /boot/config.txt
@@ -68,7 +68,7 @@ elif test "$1" = "90" -o "$2" = "90";then
 	sudo cp ./boot/config-32.txt-90 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180"  -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-180-lite /boot/config.txt
@@ -76,7 +76,7 @@ elif test "$1" = "180"  -o "$2" = "180" ;then
 	sudo cp ./boot/config-32.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270"; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-270-lite /boot/config.txt
@@ -84,7 +84,7 @@ elif test "$1" = "270" -o "$2" = "270"; then
 	sudo cp ./boot/config-32.txt-270 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare32b-overlay.dtb /boot/overlays/waveshare32b.dtbo

--- a/LCD32-show
+++ b/LCD32-show
@@ -56,11 +56,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
         if test "$j" = "retropie"; then
         sudo cp ./boot/config-32.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-32.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90";then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-90-lite /boot/config.txt
@@ -68,7 +68,7 @@ elif test "$1" = "90" -o "$2" = "90";then
 	sudo cp ./boot/config-32.txt-90 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180"  -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-180-lite /boot/config.txt
@@ -76,7 +76,7 @@ elif test "$1" = "180"  -o "$2" = "180" ;then
 	sudo cp ./boot/config-32.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270"; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32.txt-270-lite /boot/config.txt
@@ -84,7 +84,7 @@ elif test "$1" = "270" -o "$2" = "270"; then
 	sudo cp ./boot/config-32.txt-270 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare32b-overlay.dtb /boot/overlays/waveshare32b.dtbo

--- a/LCD32C-show
+++ b/LCD32C-show
@@ -57,11 +57,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
         if test "$j" = "retropie"; then
 	sudo cp ./boot/config-32c.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32c  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-32c.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90";then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32c.txt-90-lite /boot/config.txt
@@ -70,7 +70,7 @@ elif test "$1" = "90" -o "$2" = "90";then
 	sudo cp ./boot/config-32c.txt-90 /boot/config.txt
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32c-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180"  -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32c.txt-180-lite /boot/config.txt
@@ -78,7 +78,7 @@ elif test "$1" = "180"  -o "$2" = "180" ;then
 	sudo cp ./boot/config-32c.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32c-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270"; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-32c.txt-270-lite /boot/config.txt
@@ -87,7 +87,7 @@ elif test "$1" = "270" -o "$2" = "270"; then
 	sudo cp ./boot/config-32c.txt-270 /boot/config.txt
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-32c-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare32c-overlay.dtb /boot/overlays/waveshare32c.dtbo

--- a/LCD35-HDMI-480x320-show
+++ b/LCD35-HDMI-480x320-show
@@ -48,23 +48,23 @@ fi
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35H  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-35H-480x320.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35H  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-35H-480x320.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-35H-480x320.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-35H-480x320.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-35H-480x320.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 #sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 

--- a/LCD35-HDMI-800x480-show
+++ b/LCD35-HDMI-800x480-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35H  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35H  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270"  -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 

--- a/LCD35-show
+++ b/LCD35-show
@@ -57,18 +57,18 @@ if test "$1" = "0" -o "$#" = "0";then
 	if test "$j" = "retropie"; then
 	sudo cp ./boot/config-35.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-35.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
 	sudo cp ./boot/config-35.txt-90-lite /boot/config.txt
 	else
 	sudo cp ./boot/config-35.txt-90 /boot/config.txt
 	fi
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 elif test "$1" = "180" -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
@@ -76,7 +76,7 @@ elif test "$1" = "180" -o "$2" = "180" ;then
 	else
 	sudo cp ./boot/config-35.txt-180 /boot/config.txt
 	fi
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 elif test "$1" = "270" -o "$2" = "270" ; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
@@ -84,7 +84,7 @@ elif test "$1" = "270" -o "$2" = "270" ; then
 	else
 	sudo cp ./boot/config-35.txt-270 /boot/config.txt
 	fi
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 fi
 

--- a/LCD35B-show
+++ b/LCD35B-show
@@ -56,11 +56,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
 	if test "$j" = "retropie"; then
         sudo cp ./boot/config-35b.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-35b.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-35b.txt-90-lite /boot/config.txt
@@ -68,7 +68,7 @@ elif test "$1" = "90" -o "$2" = "90" ;then
 	sudo cp ./boot/config-35b.txt-90 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-35b.txt-180-lite /boot/config.txt
@@ -76,7 +76,7 @@ elif test "$1" = "180" -o "$2" = "180" ;then
 	sudo cp ./boot/config-35b.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270"; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-35b.txt-270-lite /boot/config.txt
@@ -84,7 +84,7 @@ elif test "$1" = "270" -o "$2" = "270"; then
 	sudo cp ./boot/config-35b.txt-270 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare35b-overlay.dtb /boot/overlays/waveshare35b.dtbo

--- a/LCD35B-show-V2
+++ b/LCD35B-show-V2
@@ -57,11 +57,11 @@ if test "$1" = "0" -o "$2" = "0" -o "$#" = "0" ;then
 	if test "$j" = "retropie"; then
 	sudo cp ./boot/config-35b-v2.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	sudo cp ./boot/config-35b-v2.txt /boot/config.txt
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
 	sudo cp ./boot/config-35b-v2.txt-90-lite /boot/config.txt
@@ -69,14 +69,14 @@ elif test "$1" = "90" -o "$2" = "90" ;then
 	sudo cp ./boot/config-35b-v2.txt-90 /boot/config.txt
 	fi
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180"  -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
 	sudo cp ./boot/config-35b-v2.txt-180-lite /boot/config.txt
 	else
 	sudo cp ./boot/config-35b-v2.txt-180 /boot/config.txt
 	fi
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 elif test "$1" = "270" -o "$2" = "270"; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
@@ -85,7 +85,7 @@ elif test "$1" = "270" -o "$2" = "270"; then
 	sudo cp ./boot/config-35b-v2.txt-270 /boot/config.txt
 	fi
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35b-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare35b-v2-overlay.dtb /boot/overlays/waveshare35b-v2.dtbo

--- a/LCD35C-show
+++ b/LCD35C-show
@@ -59,11 +59,11 @@ if test "$1" = "0" -o "$#" = "0"  -o "$2" = "0";then
 	if test "$j" = "retropie"; then
 	sudo cp ./boot/config-35c.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35c  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-35c.txt-lite /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
 	sudo cp ./boot/config-35c.txt-90-lite /boot/config.txt
@@ -72,14 +72,14 @@ elif test "$1" = "90" -o "$2" = "90" ;then
 	sudo cp ./boot/config-35c.txt-90 /boot/config.txt
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35c-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
 	sudo cp ./boot/config-35c.txt-180-lite /boot/config.txt
 	else
 	sudo cp ./boot/config-35c.txt-180 /boot/config.txt
 	fi
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35c-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 elif test "$1" = "270" -o "$2" = "270" ; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali"; then
@@ -89,7 +89,7 @@ elif test "$1" = "270" -o "$2" = "270" ; then
 	sudo cp ./boot/config-35c.txt-270 /boot/config.txt
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35c-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
         
 fi
 

--- a/LCD4-800x480-show
+++ b/LCD4-800x480-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-4-800x480.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-4-800x480.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-4-800x480.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-4-800x480.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-4-800x480.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 

--- a/LCD4-show
+++ b/LCD4-show
@@ -57,11 +57,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
 	if test "$j" = "retropie"; then
         sudo cp ./boot/config-4.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-4.txt /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4.txt-90-lite /boot/config.txt
@@ -69,7 +69,7 @@ elif test "$1" = "90" -o "$2" = "90" ;then
 	sudo cp ./boot/config-4.txt-90 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180"  -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4.txt-180-lite /boot/config.txt
@@ -77,7 +77,7 @@ elif test "$1" = "180"  -o "$2" = "180" ;then
 	sudo cp ./boot/config-4.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270"  -o "$2" = "270" ; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4.txt-270-lite /boot/config.txt
@@ -85,7 +85,7 @@ elif test "$1" = "270"  -o "$2" = "270" ; then
 	sudo cp ./boot/config-4.txt-270 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare35a-overlay.dtb /boot/overlays/waveshare35a.dtbo

--- a/LCD43-show
+++ b/LCD43-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 

--- a/LCD43-show-V2
+++ b/LCD43-show-V2
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-v2 /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-v2 /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-90-v2 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-180-v2 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-43-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-43.txt-270-v2 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 

--- a/LCD4C-show
+++ b/LCD4C-show
@@ -61,11 +61,11 @@ if test "$1" = "0" -o "$#" = "0" -o "$2" = "0";then
 	if test "$j" = "retropie"; then
 	sudo cp ./boot/config-4c.txt-retropie /boot/config.txt
 	fi
-	echo "LCD configrue 0"
+	echo "LCD configure 0"
 elif test "$1" = "lite" -a "$#" = "1" ;then
         sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4c  /usr/share/X11/xorg.conf.d/99-calibration.conf
         sudo cp ./boot/config-4c.txt-lite /boot/config.txt
-        echo "LCD configrue 0"
+        echo "LCD configure 0"
 elif test "$1" = "90"  -o "$2" = "90" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4c.txt-90-lite /boot/config.txt
@@ -74,7 +74,7 @@ elif test "$1" = "90"  -o "$2" = "90" ;then
 	sudo cp ./boot/config-4c.txt-90 /boot/config.txt
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4c-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 90"
+	echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4c.txt-180-lite /boot/config.txt
@@ -82,7 +82,7 @@ elif test "$1" = "180" -o "$2" = "180" ;then
 	sudo cp ./boot/config-4c.txt-180 /boot/config.txt
 	fi
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4c-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
-	echo "LCD configrue 180"
+	echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270" ; then
 	if test "$1" = "lite" -o "$2" = "lite" -o "$j" = "kali" ; then
 	sudo cp ./boot/config-4c.txt-270-lite /boot/config.txt
@@ -91,7 +91,7 @@ elif test "$1" = "270" -o "$2" = "270" ; then
 	sudo cp ./boot/config-4c.txt-270 /boot/config.txt
 	sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-4c-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 	fi
-	echo "LCD configrue 270"
+	echo "LCD configure 270"
 fi
 
 sudo cp ./waveshare4c-overlay.dtb /boot/overlays/waveshare4c.dtbo

--- a/LCD5-show
+++ b/LCD5-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-5.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 

--- a/LCD7-1024x600-show
+++ b/LCD7-1024x600-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0" ; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-1024x600.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-1024x600.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90" ; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-1024x600.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-1024x600.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270" ;then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-1024x600.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 

--- a/LCD7-800x480-show
+++ b/LCD7-800x480-show
@@ -44,23 +44,23 @@ sudo cp -rf ./etc/rc.local /etc/rc.local
 if test "$1" = "0" -o "$#" = "0" -o "$2" = "0"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-800x480.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "lite" -a  "$#" = "1"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-800x480.txt /boot/config.txt
-echo "LCD configrue 0"
+echo "LCD configure 0"
 elif test "$1" = "90" -o "$2" = "90"; then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-90  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-800x480.txt-90 /boot/config.txt
-echo "LCD configrue 90"
+echo "LCD configure 90"
 elif test "$1" = "180" -o "$2" = "180";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-180  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-800x480.txt-180 /boot/config.txt
-echo "LCD configrue 180"
+echo "LCD configure 180"
 elif test "$1" = "270" -o "$2" = "270";then
 sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
 sudo cp ./boot/config-7-800x480.txt-270 /boot/config.txt
-echo "LCD configrue 270"
+echo "LCD configure 270"
 fi
 
 sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 


### PR DESCRIPTION
Corrects the `configrue` instead of `configure` typo that is present in most if not all the install scripts. 

Basically a quick application of `for i in *; do sed -i 's/configrue/configure/g' "$i"; done` to apply the correction.